### PR TITLE
pre-post

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ When `f` is called **post** invocation the following information will also be pr
 | `:result` | The result computed by applying the value of `:function` to the value of `:args`. |
 | `:error`  | Any exception caught during computation of the result.                            |
 
+ ## `wiretap.wiretap/install-pre!`
+ ```clojure
+ (install-pre! [f vars])
+ ```
+ Like `install!` but ensures that `f` is only called **pre** invocation. Useful if you are not interested in the results of the wiretapped vars.
+
+ ## `wiretap.wiretap/install-post!`
+ ```clojure
+ (install-post! [f vars])
+ ```
+Like `install!` but ensures that `f` is only called **post** invocation. Useful if you only care about the results of the wiretapped vars.
+
+
 
 
  ## `wiretap.wiretap/uninstall!`
@@ -106,14 +119,11 @@ When `f` is called **post** invocation the following information will also be pr
  ```clojure
  (uninstall! ([]) ([vars]))
  ```
+Uninstalls all wiretaps from all applicable vars in vars.
 
-Sets the root binding of every applicable var to a be the value before calling
-   `install!`. If called without any arguments then all vars in namespaces available
-   via `clojure.core/all-ns` will be checked.
+> A var is considered applicable if the key `:wiretap.wiretap/uninstall` is present in the metadata and the key `:wiretap.wiretap/exclude` is not.
 
-> A var is considered applicable if has been wiretapped and its metadata does not contain the key `:wiretap.wiretap/exclude`.
-
-   Returns a coll of all modified vars.
+Returns a coll of all modified vars.   
 
  ## `wiretap.tools/ns-matches-vars`
 

--- a/src/wiretap/wiretap.clj
+++ b/src/wiretap/wiretap.clj
@@ -116,33 +116,102 @@
 
    ### Multimethods 
 
-   If the wiretapped var is a multimethod then the following information will also be present.   
+   If the wiretapped var is a multimethod then the following information will also be present.
 
-   | Key              | Value                                         | 
-   | ---------------- | --------------------------------------------- |
-   | `:multimethod?`  | `true`                                        |
-   | `:dispatch-val`  | The dispatch value used to select the method. |
+   | Key              | Value                                                       |
+   | ---------------- | ----------------------------------------------------------- |
+   | `:multimethod?`  | `true`                                                      |
+   | `:dispatch-val`  | The dispatch value used to select the method.               |
 
    ### Pre invocation
 
    When `f` is called **pre** invocation the following information will also be present.
-   | Key     | Value  |
-   | ------- | -------|
-   | `:pre?` | `true` |
+
+   | Key         | Value                                                            |
+   | ----------- | ---------------------------------------------------------------- |
+   | `:pre?`     | `true`                                                           |
 
    ### Post invocation
 
    When `f` is called **post** invocation the following information will also be present.
 
-   | Key       | Value                                                                             |
-   | --------- | --------------------------------------------------------------------------------- |
-   | `:post?`  | `true`                                                                            |
-   | `:stop`   | Nanoseconds since some fixed but arbitrary origin time.                           |
-   | `:result` | The result computed by applying the value of `:function` to the value of `:args`. |
-   | `:error`  | Any exception caught during computation of the result.                            |
+   | Key       | Value                                                              |
+   | --------- | ------------------------------------------------------------------ |
+   | `:post?`  | `true`                                                             |
+   | `:stop`   | Nanoseconds since some fixed but arbitrary origin time.            |
+   | `:result` | The result of applying the value of `:function` to `:args`.        |
+   | `:error`  | Any exception caught during computation of the result.             |
    "
   [f vars]
   (doall (keep (partial wiretap-var! f) vars)))
+
+(defn install-pre!
+  "Like `install!` but ensures that `f` is only called **pre** invocation.
+
+   The following contextual data is will **always** be present in the map passed
+   to `f`:
+
+   | Key         | Value                                                            |
+   | ----------- | ---------------------------------------------------------------- |
+   | `:id`       | Uniquely identifies the call. Same value for pre and post calls. |
+   | `:name`     | A symbol. Taken from the _meta_ of the var.                      |
+   | `:ns`       | A namespace. Taken from the _meta_ of the var.                   |
+   | `:function` | The value that will be applied to the value of `:args`.          |
+   | `:thread`   | The name of the thread.                                          |
+   | `:stack`    | The current stacktrace.                                          |
+   | `:depth`    | Number of _wiretapped_ function calls on the stack.              |
+   | `:args`     | The seq of args that value of `:function` will be applied to.    |
+   | `:start`    | Nanoseconds since some fixed but arbitrary origin time.          |
+   | `:parent`   | The context of the previous wiretapped function on the stack.    |
+   | `:pre?`     | `true`                                                           |
+
+   ### Multimethods
+
+   If the wiretapped var is a multimethod then the following information will also be present.
+
+   | Key              | Value                                                       |
+   | ---------------- | ----------------------------------------------------------- |
+   | `:multimethod?`  | `true`                                                      |
+   | `:dispatch-val`  | The dispatch value used to select the method.               |
+   "
+  [f vars]
+  (install! #(when (:pre? %) (f %)) vars))
+
+(defn install-post!
+  "Like `install!` but ensures that `f` is only called **post** invocation.
+
+   The following contextual data is will **always** be present in the map passed
+   to `f`:
+
+   | Key         | Value                                                            |
+   | ----------- | ---------------------------------------------------------------- |
+   | `:id`       | Uniquely identifies the call. Same value for pre and post calls. |
+   | `:name`     | A symbol. Taken from the _meta_ of the var.                      |
+   | `:ns`       | A namespace. Taken from the _meta_ of the var.                   |
+   | `:function` | The value that will be applied to the value of `:args`.          |
+   | `:thread`   | The name of the thread.                                          |
+   | `:stack`    | The current stacktrace.                                          |
+   | `:depth`    | Number of _wiretapped_ function calls on the stack.              |
+   | `:args`     | The seq of args that value of `:function` will be applied to.    |
+   | `:start`    | Nanoseconds since some fixed but arbitrary origin time.          |
+   | `:parent`   | The context of the previous wiretapped function on the stack.    |
+   | `:post?`    | `true`                                                           |
+   | `:stop`     | Nanoseconds since some fixed but arbitrary origin time.          |
+   | `:result`   | The result of applying the value of `:function` to `:args`.      |
+   | `:error`    | Any exception caught during computation of the result.           |
+
+   ### Multimethods
+
+   If the wiretapped var is a multimethod then the following information will also be present.
+
+   | Key              | Value                                                       |
+   | ---------------- | ----------------------------------------------------------- |
+   | `:multimethod?`  | `true`                                                      |
+   | `:dispatch-val`  | The dispatch value used to select the method.               |
+   "
+  [f vars]
+  (install! #(when (:post? %) (f %)) vars))
+
 
 ;; (defn- ^::exclude wiretap-multifn-dispatch! [f var-obj]
 ;;   (let [var-meta (meta var-obj)


### PR DESCRIPTION
Having to constantly check the `:pre?` key because you only care about the state of the context (before/after) the function call is tedious. It would be nice to be able to specify that you only want your supplied function to run pre or post invocation. 

Adds `install-pre!` and `install-post!` helper functions that mimic the existing `install!` for readability and simplicity.