### PR TITLE
Add history ns

### DIFF
--- a/src/wiretap/record.clj
+++ b/src/wiretap/record.clj
@@ -1,0 +1,51 @@
+(ns wiretap.record
+    "Provides functions for recording and playing back events traced by
+     the wiretap library. This includes utilities for matching namespaces,
+     installing a basic event-recording tracer, and displaying the recorded events."
+  (:require [wiretap.wiretap :as wiretap]
+            [wiretap.tools :as tools]))
+
+(defn ^:wiretap.wiretap/exclude start!
+  "Installs a tracer function on a set of Vars derived from the provided options.
+   This tracer records all call/return context maps into an events atom.
+
+  Options map keys:
+  `:vars` - A sequence of Vars to explicitly instrument.
+  `:globs` - A sequence of strings that use the glob patterns * and ** to match against
+             namespaces - eg \"my-proj.**\" and \"my-proj.*.bar.**.baz\"
+
+  Returns a map with keys :vars and :events containing the wiretapped vars and events atom"
+  [{:keys [vars globs] :as options}]
+  (let [possible-vars (into (set vars) (tools/globs-vars globs))
+        events (atom [])
+        modified-vars (wiretap/install! #(swap! events conj %) possible-vars)]
+    {:vars modified-vars :events events}))
+
+(defn ^:wiretap.wiretap/exclude events
+  "Returns a vector of all recorded trace events.
+
+  See `wiretap.wiretap/install!` for full documentation of event context maps."
+  [{:keys [events] :as recorder}]
+  @events)
+
+(defn ^:wiretap.wiretap/exclude wipe!
+  "Clears all recorded trace events from the recording.
+
+  The wiretap remains installed and will continue recording new events."
+  [{:keys [events] :as recorder}]
+  (reset! events []))
+
+(defn ^:wiretap.wiretap/exclude playback
+  "Prints recorded trace events to the console in a formatted, indented style.
+
+  Shows function calls with arguments on entry and results on exit."
+  [{:keys [events] :as recorder}]
+  (tools/display-trace @events))
+
+(defn ^:wiretap.wiretap/exclude stop!
+  "Removes the wiretap from all instrumented vars, restoring their original behavior.
+
+  After uninstalling, the vars will no longer record trace events. The existing
+  recorded events remain accessible until cleared."
+  [{:keys [vars] :as recorder}]
+  (wiretap/uninstall! vars))

--- a/src/wiretap/tools.clj
+++ b/src/wiretap/tools.clj
@@ -1,27 +1,107 @@
-(ns wiretap.tools)
+(ns wiretap.tools
+    (:require [clojure.string :as str]))
 
-(defn ns-vars [& namespaces]
-  (mapcat #(vals (ns-interns %)) (set namespaces)))
+(defn ^:wiretap.wiretap/exclude ns-vars [& namespaces]
+  (into []
+        (mapcat #(vals (ns-interns %)))
+        (set namespaces)))
 
-(defn ns-matches
-  "Given an instance of java.util.regex.Pattern, returns a sorted coll of symbols 
+(defn ^:wiretap.wiretap/exclude ns-matches
+  "Given an instance of java.util.regex.Pattern, returns a vector of symbols
    naming the currently loaded libs that are matched by `regex`."
   {:doc/format :markdown}
   [regex]
-  (->> (loaded-libs)
-       (filter
-        (comp (partial re-matches regex) name))))
+  (into []
+        (comp
+          (map #(.getName %))
+          (filter
+            (comp (partial re-matches regex) name)))
+        (all-ns)))
 
-(defn ns-matches-vars
-  "Given an instance of java.util.regex.Pattern, returns a seq of all vars 
+(defn ^:wiretap.wiretap/exclude ns-matches-vars
+  "Given an instance of java.util.regex.Pattern, returns a vector of all vars
    that have been interned in namespaces matched by the regex"
   {:doc/format :markdown}
   [regex]
   (apply ns-vars (ns-matches regex)))
 
-(defn wiretapped? [var-obj] 
+(defn ^:wiretap.wiretap/exclude wiretapped? [var-obj]
   (boolean (:wiretap.wiretap/uninstall (meta var-obj))))
 
-(defn filter-trace [pattern trace]
+(defn ^:wiretap.wiretap/exclude filter-trace [pattern trace]
   (->> (map #(.getClassName %) trace)
        (keep #(re-matches pattern %))))
+
+(defn ^:wiretap.wiretap/exclude glob-regex
+  "Converts a namespace glob pattern into a compiled regex Pattern.
+
+  Glob syntax:
+  - `*` matches a single namespace segment (e.g., 'foo.*.bar' matches 'foo.baz.bar')
+  - `**` matches zero or more segments (e.g., 'foo.**' matches 'foo.bar.baz')
+  - Literal segments match exactly
+
+  Returns a java.util.regex.Pattern suitable for matching namespace names."
+
+  [glob-pattern]
+  (let [d "\\."
+        g "[^\\.]*"
+        gs "(\\..*?)*"]
+    (->>
+      (reduce (fn [path segment]
+                (let [prev (last path)
+                      next-segments
+                      (cond
+                        (nil? prev) [(case segment
+                                       "*" g
+                                       "**" gs
+                                       segment)]
+                        (= prev g) (case segment
+                                     "*" [d g]
+                                     "**" [gs]
+                                     [d segment])
+                        (= prev gs) (case segment
+                                      ("*" "**") [] ;; consumed by the previous **
+                                      [d segment])
+                        :else (case segment
+                                "*" [d g]
+                                "**" [gs]
+                                [d segment]))]
+                  (into path next-segments)))
+              []
+              (str/split glob-pattern #"\."))
+      (str/join)
+      (format "^%s$")
+      (re-pattern))))
+
+(defn ^:wiretap.wiretap/exclude globs-vars
+  "Given a collection of glob patterns, returns a vector of all matching vars.
+
+  Example: (globs-vars [\"foo.**.bar\" \"foo.*.baz\"])"
+  [glob-patterns]
+  (into []
+        (comp (map glob-regex)
+              (mapcat ns-matches-vars))
+        glob-patterns))
+
+(defn- ^:wiretap.wiretap/exclude basic-trace
+  "A basic, internal tracer function for printing call trace information
+   to the console. It handles indentation and associates temporary IDs
+   with function calls to link pre-call (entry) and post-call (exit) events."
+  [trace-id-atom {:keys [id pre? depth name ns args result] :as ctx}]
+  (let [trace-id (if pre? (gensym "t") (get @trace-id-atom id))
+        trace-indent (apply str (take depth (repeat "| ")))
+        trace-value (if pre?
+                      (str trace-indent (pr-str (cons (symbol (ns-resolve ns name)) args)))
+                      (str trace-indent "=> " (pr-str result)))]
+    (if pre?
+      (swap! trace-id-atom assoc id trace-id)
+      (swap! trace-id-atom dissoc id))
+    (println (str "TRACE" (str " " trace-id) ": " trace-value))))
+
+(defn ^:wiretap.wiretap/exclude display-trace
+  "Prints a sequence of trace events (history) to the console using a
+   basic-trace format.
+
+  `history` is expected to be a sequence of wiretap context maps."
+  [history]
+  (run! (partial basic-trace (atom {})) history))

--- a/test/wiretap/ns_to_inspect.clj
+++ b/test/wiretap/ns_to_inspect.clj
@@ -38,4 +38,3 @@
 
 (defmethod my-multi :dog [{:keys [name]}]
   {:the-dog name})
-

--- a/test/wiretap/other_ns_to_inspect.clj
+++ b/test/wiretap/other_ns_to_inspect.clj
@@ -1,0 +1,7 @@
+(ns wiretap.other-ns-to-inspect)
+
+(defn beep [x y]
+  (+ x y))
+
+(defn boop [x]
+  (beep x x))

--- a/test/wiretap/record_test.clj
+++ b/test/wiretap/record_test.clj
@@ -1,0 +1,176 @@
+(ns wiretap.record-test
+    (:require [clojure.set :as set]
+              [clojure.test :refer :all]
+              [wiretap.record :as rec]
+              [wiretap.tools :as tools]
+              [wiretap.ns-to-inspect :as ns1]
+              [wiretap.other-ns-to-inspect :as ns2]))
+
+;; Basic capture tests
+
+(deftest capture-with-globs-test
+  (testing "capture! instruments functions matching glob patterns"
+    (let [cap (rec/start! {:globs ["wiretap.ns-to-inspect"]})
+          _ (ns1/simple 42)
+          events (rec/events cap)]
+      (is (seq (:vars cap)))
+      (is (seq events))
+      (is (some #(and (:pre? %) (= 'simple (:name %))) events))
+      (is (some #(and (:post? %) (= 'simple (:name %))) events))
+      (rec/stop! cap))))
+
+(deftest capture-with-explicit-vars-test
+  (testing "capture! instruments explicitly provided vars"
+    (let [cap (rec/start! {:vars [#'ns1/simple]})
+          _ (ns1/simple 99)
+          events (rec/events cap)]
+      (is (= 1 (count (:vars cap))))
+      (is (seq events))
+      (is (some #(= 'simple (:name %)) events))
+      (rec/stop! cap))))
+
+(deftest capture-with-globs-and-vars-test
+  (testing "capture! combines globs and explicit vars"
+    (let [cap (rec/start! {:globs ["wiretap.other-ns-to-inspect"]
+                           :vars [#'ns1/simple]})
+          _ (ns1/simple 1)
+          _ (ns2/beep 2 3)
+          events (rec/events cap)
+          event-names (set (map :name events))]
+      (is (contains? event-names 'simple))
+      (is (contains? event-names 'beep))
+      (rec/stop! cap))))
+
+;; Event structure tests
+
+(deftest captured-events-have-required-keys-test
+  (testing "captured events contain required context keys"
+    (let [cap (rec/start! {:vars [#'ns1/simple]})
+          _ (ns1/simple 42)
+          events (rec/events cap)
+          pre-event (first (filter :pre? events))
+          post-event (first (filter :post? events))]
+      (is pre-event "should have pre event")
+      (is post-event "should have post event")
+      ;; Pre event keys
+      (is (:id pre-event))
+      (is (:name pre-event))
+      (is (:ns pre-event))
+      (is (:args pre-event))
+      (is (:depth pre-event))
+      (is (:thread pre-event))
+      (is (:start pre-event))
+      (is (:pre? pre-event))
+      ;; Post event keys
+      (is (:id post-event))
+      (is (:result post-event))
+      (is (:post? post-event))
+      (is (:stop post-event))
+      ;; Same ID for pre and post
+      (is (= (:id pre-event) (:id post-event)))
+      (rec/stop! cap))))
+
+(deftest captured-events-preserve-call-order-test
+  (testing "events are captured in call order"
+    (let [cap (rec/start! {:vars [#'ns1/call-simple]})
+          _ (ns1/call-simple 123)
+          events (rec/events cap)
+          call-simple-pre (first (filter #(and (:pre? %) (= 'call-simple (:name %))) events))
+          call-simple-post (first (filter #(and (:post? %) (= 'call-simple (:name %))) events))]
+      (is call-simple-pre)
+      (is call-simple-post)
+      (is (= [123] (:args call-simple-pre)))
+      (is (= 123 (:result call-simple-post)))
+      (rec/stop! cap))))
+
+;; clear! tests
+
+(deftest clear-removes-events-test
+  (testing "clear! removes all captured events"
+    (let [cap (rec/start! {:vars [#'ns1/simple]})
+          _ (ns1/simple 1)
+          _ (ns1/simple 2)
+          events-before (rec/events cap)
+          _ (rec/wipe! cap)
+          events-after (rec/events cap)]
+      (is (seq events-before))
+      (is (empty? events-after))
+      (rec/stop! cap))))
+
+(deftest clear-preserves-instrumentation-test
+  (testing "clear! preserves instrumentation, new calls still captured"
+    (let [cap (rec/start! {:vars [#'ns1/simple]})
+          _ (ns1/simple 1)
+          _ (rec/wipe! cap)
+          _ (ns1/simple 2)
+          events (rec/events cap)]
+      (is (seq events))
+      (is (some #(= [2] (:args %)) events))
+      (rec/stop! cap))))
+
+;; uninstall! tests
+
+(deftest uninstall-removes-instrumentation-test
+  (testing "uninstall! removes instrumentation from vars"
+    (let [cap (rec/start! {:vars [#'ns1/simple]})
+          _ (is (tools/wiretapped? #'ns1/simple))
+          _ (rec/stop! cap)]
+      (is (not (tools/wiretapped? #'ns1/simple))))))
+
+(deftest uninstall-stops-capturing-test
+  (testing "after uninstall!, calls are no longer captured"
+    (let [cap (rec/start! {:vars [#'ns1/simple]})
+          _ (ns1/simple 1)
+          events-before (count (rec/events cap))
+          _ (rec/stop! cap)
+          _ (ns1/simple 2)
+          events-after (count (rec/events cap))]
+      (is (= events-before events-after)))))
+
+;; Multiple captures
+
+(deftest multiple-captures-independent-test
+  (testing "multiple captures operate independently"
+    (let [cap1 (rec/start! {:vars [#'ns1/simple]})
+          cap2 (rec/start! {:vars [#'ns2/beep]})
+          _ (ns1/simple 1)
+          _ (ns2/beep 2 3)
+          events1 (rec/events cap1)
+          events2 (rec/events cap2)]
+      (is (some #(= 'simple (:name %)) events1))
+      (is (not-any? #(= 'beep (:name %)) events1))
+      (is (some #(= 'beep (:name %)) events2))
+      (is (not-any? #(= 'simple (:name %)) events2))
+      (rec/stop! cap1)
+      (rec/stop! cap2))))
+
+(deftest overlapping-captures-test
+  (testing "when two captures instrument same var, second one wins"
+    (let [cap1 (rec/start! {:vars [#'ns1/simple]})
+          cap2 (rec/start! {:vars [#'ns1/simple]})
+          _ (ns1/simple 42)
+          events1 (rec/events cap1)
+          events2 (rec/events cap2)]
+      ;; cap2 should capture the event, cap1 should not
+      (is (empty? events1))
+      (is (seq events2))
+      (is (some #(= 'simple (:name %)) events2))
+      (rec/stop! cap1)
+      (rec/stop! cap2))))
+
+;; Nested calls
+
+(deftest nested-calls-captured-test
+  (testing "nested function calls are captured with correct depth"
+    (let [cap (rec/start! {:globs ["wiretap.ns-to-inspect"]})
+          _ (ns1/call-simple 42)
+          events (rec/events cap)
+          call-simple-events (filter #(= 'call-simple (:name %)) events)
+          simple-events (filter #(= 'simple (:name %)) events)]
+      (is (seq call-simple-events))
+      (is (seq simple-events))
+      ;; simple should have greater depth than call-simple
+      (let [call-simple-depth (:depth (first call-simple-events))
+            simple-depth (:depth (first simple-events))]
+        (is (< call-simple-depth simple-depth)))
+      (rec/stop! cap))))

--- a/test/wiretap/tools_test.clj
+++ b/test/wiretap/tools_test.clj
@@ -1,0 +1,128 @@
+(ns wiretap.tools-test
+    (:require [clojure.set :as set]
+              [clojure.test :refer :all]
+              [wiretap.tools :as tools]
+              [wiretap.ns-to-inspect]
+              [wiretap.other-ns-to-inspect]))
+
+;; glob-regex tests
+
+(deftest glob-regex-literal-test
+  (testing "literal segments match exactly"
+    (let [pattern (tools/glob-regex "foo.bar.baz")]
+      (is (re-matches pattern "foo.bar.baz"))
+      (is (nil? (re-matches pattern "foo.bar.qux")))
+      (is (nil? (re-matches pattern "foo.bar"))))))
+
+(deftest glob-regex-single-wildcard-test
+  (testing "* matches exactly one segment"
+    (let [pattern (tools/glob-regex "foo.*.baz")]
+      (is (re-matches pattern "foo.bar.baz"))
+      (is (re-matches pattern "foo.qux.baz"))
+      (is (nil? (re-matches pattern "foo.baz")))
+      (is (nil? (re-matches pattern "foo.bar.qux.baz"))))))
+
+(deftest glob-regex-double-wildcard-test
+  (testing "** matches zero or more segments"
+    (let [pattern (tools/glob-regex "foo.**")]
+      (is (re-matches pattern "foo"))
+      (is (re-matches pattern "foo.bar"))
+      (is (re-matches pattern "foo.bar.baz"))
+      (is (re-matches pattern "foo.bar.baz.qux"))
+      (is (nil? (re-matches pattern "other.bar"))))))
+
+(deftest glob-regex-double-wildcard-middle-test
+  (testing "** in the middle matches zero or more segments"
+    (let [pattern (tools/glob-regex "foo.**.baz")]
+      (is (re-matches pattern "foo.baz"))
+      (is (re-matches pattern "foo.bar.baz"))
+      (is (re-matches pattern "foo.x.y.z.baz"))
+      (is (nil? (re-matches pattern "foo.bar"))))))
+
+(deftest glob-regex-mixed-wildcards-test
+  (testing "combination of * and ** wildcards"
+    (let [pattern (tools/glob-regex "foo.*.**.baz")]
+      (is (re-matches pattern "foo.bar.baz"))
+      (is (re-matches pattern "foo.bar.x.y.baz"))
+      (is (nil? (re-matches pattern "foo.baz"))))))
+
+;; ns-matches tests
+
+(deftest ns-matches-finds-test-namespaces
+  (testing "ns-matches finds loaded test namespaces"
+    (let [pattern (re-pattern "wiretap\\..*-to-inspect")
+          matches (set (tools/ns-matches pattern))]
+      (is (contains? matches 'wiretap.ns-to-inspect))
+      (is (contains? matches 'wiretap.other-ns-to-inspect)))))
+
+(deftest ns-matches-with-glob-pattern
+  (testing "ns-matches works with glob-regex generated patterns"
+    (let [matches (set (tools/ns-matches (tools/glob-regex "wiretap.**")))]
+      (is (set/subset? #{'wiretap.ns-to-inspect
+                         'wiretap.other-ns-to-inspect}
+                       matches)))))
+
+(deftest ns-matches-returns-symbols
+  (testing "ns-matches returns symbols not strings or namespace objects"
+    (let [matches (tools/ns-matches (tools/glob-regex "wiretap.**"))]
+      (is (every? symbol? matches)))))
+
+;; ns-vars tests
+
+(deftest ns-vars-basic-test
+  (testing "ns-vars returns vars from a single namespace"
+    (let [vars (tools/ns-vars 'wiretap.ns-to-inspect)]
+      (is (seq vars))
+      (is (every? var? vars))
+      (is (some #(= 'simple (:name (meta %))) vars)))))
+
+(deftest ns-vars-multiple-namespaces-test
+  (testing "ns-vars combines vars from multiple namespaces"
+    (let [vars (set (tools/ns-vars 'wiretap.ns-to-inspect 'wiretap.other-ns-to-inspect))
+          var-names (set (map #(:name (meta %)) vars))]
+      (is (contains? var-names 'simple))
+      (is (contains? var-names 'beep))
+      (is (contains? var-names 'boop)))))
+
+(deftest ns-vars-deduplicates-test
+  (testing "ns-vars deduplicates when same namespace passed multiple times"
+    (let [vars1 (tools/ns-vars 'wiretap.ns-to-inspect 'wiretap.ns-to-inspect)
+          vars2 (tools/ns-vars 'wiretap.ns-to-inspect)]
+      (is (= (set vars1) (set vars2))))))
+
+;; ns-matches-vars tests
+
+(deftest ns-matches-vars-test
+  (testing "ns-matches-vars combines ns-matches and ns-vars"
+    (let [vars (tools/ns-matches-vars (re-pattern "wiretap\\.ns-to-inspect"))
+          var-names (set (map #(:name (meta %)) vars))]
+      (is (contains? var-names 'simple))
+      (is (contains? var-names 'call-simple)))))
+
+;; globs-vars tests
+
+(deftest globs-vars-single-glob-test
+  (testing "globs-vars works with single glob pattern"
+    (let [vars (tools/globs-vars ["wiretap.ns-to-inspect"])
+          var-names (set (map #(:name (meta %)) vars))]
+      (is (contains? var-names 'simple)))))
+
+(deftest globs-vars-multiple-globs-test
+  (testing "globs-vars combines results from multiple glob patterns"
+    (let [vars (tools/globs-vars ["wiretap.ns-to-inspect" "wiretap.other-ns-to-inspect"])
+          var-names (set (map #(:name (meta %)) vars))]
+      (is (contains? var-names 'simple))
+      (is (contains? var-names 'beep))
+      (is (contains? var-names 'boop)))))
+
+(deftest globs-vars-double-wildcard-test
+  (testing "globs-vars works with ** wildcard"
+    (let [vars (tools/globs-vars ["wiretap.**"])
+          var-names (set (map #(:name (meta %)) vars))]
+      (is (contains? var-names 'simple))
+      (is (contains? var-names 'beep)))))
+
+(deftest globs-vars-returns-vector
+  (testing "globs-vars returns a vector"
+    (let [result (tools/globs-vars ["wiretap.ns-to-inspect"])]
+      (is (vector? result)))))

--- a/test/wiretap/wiretap_test.clj
+++ b/test/wiretap/wiretap_test.clj
@@ -178,3 +178,17 @@
 
 (comment
   (run! (partial ns-unmap *ns*) (keys (ns-interns *ns*))))
+
+(test/deftest wiretap-twice-test
+  (let [state1 (atom [])
+        state2 (atom [])]
+    (wiretap/install! #(swap! state1 conj %) vars-of-interest)
+    (sut/call-simple 1)
+    (test/is (count @state1) 2)
+    (test/is (count @state2) 0)
+    (test/testing "Wiretapping with a second listener replaces the first"
+      (reset! state1 [])
+      (wiretap/install! #(swap! state2 conj %) vars-of-interest)
+      (sut/call-simple 1)
+      (test/is (count @state1) 2)
+      (test/is (count @state2) 2))))


### PR DESCRIPTION
A new `record` namespace with functions for simplifying setting up a wiretap.

empty point is "start!" that returns a map with keys :recording and :vars

where recording is an atom (vector) and vars are set of all wiretapped vars.